### PR TITLE
fix xlstm layer initialization

### DIFF
--- a/xlstm/llm.py
+++ b/xlstm/llm.py
@@ -108,8 +108,8 @@ class xLSTM(LightningModule):
         which = [True] * m_num + [False] * s_num
         
         self.llm : List[mLSTM | sLSTM] = nn.ModuleList([
-            mLSTM(**mlstm_par) if w else sLSTM(**slstm_par)
-            for w, _ in zip(repeat(which), range(num_layers))
+            mLSTM(**mlstm_par) if v else sLSTM(**slstm_par)
+            for w in repeat(which, num_layers) for v in w
         ])
         
         # Prediction head to map the output of the xLSTM model to the vocabulary
@@ -144,7 +144,7 @@ class xLSTM(LightningModule):
         seq : Tensor = self.embedding(tok)
         
         if batch_first: seq = rearrange(seq, 'b s i -> s b i')
-        if hid is None: hid = [l.init_hidden(seq.size(1)) for l in self.llm]
+        if hid is None: hid = [l.init_hidden(seq.shape[1]) if isinstance(l, mLSTM) else l.init_hidden() for l in self.llm]
         
         # Pass the sequence through the mLSTM and sLSTM blocks
         out = []

--- a/xlstm/utils.py
+++ b/xlstm/utils.py
@@ -100,7 +100,7 @@ class BlockLinear(nn.Module):
         # Assemble the blocks into a block-diagonal matrix
         full = torch.block_diag(*self._blocks)
         
-        out = torch.matmul(full, inp)
+        out = torch.matmul(inp, full)
         
         if self._bias is not None:
             out = out + self._bias


### PR DESCRIPTION
I noticed a bug in the current initialization of `self.llm`, which only adds `mLSTM` layers to the `xLSTM` block. In the current initialization the type of `w` is a list, so the if-statements which is supposed to determine the layer is actually just checking if the list is empty.

I only noticed this because in the forward pass on [line 147](https://github.com/myscience/x-lstm/blob/main/xlstm/llm.py#L147) `init_hidden` is called on the layer with a single parameter, but the `sLSTM.init_hidden` method doesn't take a parameter. 

This repo has been super helpful while reading the paper, so thank you for putting it together! Let me know if I need to fix anything else to get this merged.